### PR TITLE
Fixing error in flight log markdown possibly causing site build to break

### DIFF
--- a/flight-logs/2024-03-18-cocreate.md
+++ b/flight-logs/2024-03-18-cocreate.md
@@ -17,7 +17,7 @@ tags: [log, sprint ]
     - Changed ``SubnetId: !Ref PublicSubnet1ID``  to ``SubnetId: <PrivateSubnetID>`` to account for private deployments
     - Updated LambdaExecutionRole.json line 14: from ``ec2.aws.com`` to ``lambda.aws.com`` and added ``cloudformation.aws.com`` of allowed services.
     - Fixed LambdaExecutionRole ARN to proper role name.
-    - Commented out /bin/bash ./cp-deploy.sh env apply -e env_id=${ClusterName} [--accept-all-licenses]
+    - Commented out ```/bin/bash ./cp-deploy.sh env apply -e env_id=${ClusterName} [--accept-all-licenses]```
     - Added VPC and Subnet IDs to the “CleanupLambda”  lambda function in cluster-sts, which then required adding “ec2:CreateNetworkInterface” permission to LambdaExecutionRole
     - Adding tags to CleanupLambda with Application IDs.
 - Successful deployment of BootNode instance.


### PR DESCRIPTION
Docusaurus site build was failing due to a ClusterName not defined issue, possibly because of something in the markdown trying to pull an env variable.